### PR TITLE
Bug fix for plotting multiple markers

### DIFF
--- a/views/helpers/geomap.php
+++ b/views/helpers/geomap.php
@@ -298,6 +298,7 @@ class GeomapHelper extends AppHelper {
 		}
 
 		if (!empty($markers)) {
+			$i = 0;
 			foreach($markers as $marker) {
 				$markerOptions = array(
 					'title' => null,
@@ -312,7 +313,7 @@ class GeomapHelper extends AppHelper {
 
 				if ($parameters['version'] >= 3) {
 					$script .= '
-						marker = new google.maps.Marker({
+						marker'.$i.' = new google.maps.Marker({
 							map: ' . $varName . ',
 							position: new google.maps.LatLng(' . $latitude . ', ' . $longitude . '),
 							title: "' . (!empty($markerOptions['title']) ? $markerOptions['title'] : '') . '",
@@ -327,8 +328,8 @@ class GeomapHelper extends AppHelper {
 							infoWindow = new google.maps.InfoWindow({
 								content: "' . $content . '"
 							});
-							google.maps.event.addListener(marker, \'click\', function() {
-								infoWindow.open(' . $varName . ', marker);
+							google.maps.event.addListener(marker'.$i.', \'click\', function() {
+								infoWindow.open(' . $varName . ', marker'.$i.');
 							});
 						';
 
@@ -344,16 +345,17 @@ class GeomapHelper extends AppHelper {
 						';
 					}
 
-					$script .= 'marker = new google.maps.Marker(new google.maps.LatLng(' . $latitude . ', ' . $longitude . '), markerOptions);';
-					$script .= $varName . '.addOverlay(marker);';
+					$script .= 'marker'.$i.' = new google.maps.Marker(new google.maps.LatLng(' . $latitude . ', ' . $longitude . '), markerOptions);';
+					$script .= $varName . '.addOverlay(marker'.$i.');';
 
 					if (!empty($content)) {
-						$script .= 'google.maps.Event.addListener(marker, \'click\', function() {
-							marker.openInfoWindowHtml("' . $content . '");
+						$script .= 'google.maps.Event.addListener(marker'.$i.', \'click\', function() {
+							marker'.$i.'.openInfoWindowHtml("' . $content . '");
 						});
 						';
 					}
 				}
+				$i++;
 			}
 		}
 


### PR DESCRIPTION
Just fixed a little bug I stumbled on. When I would go to plot multiple markers at once, all of their info bubbles opened at the last marker which was plotted. This seems like it was due to creating the marker variable multiple times only with different info bubbles... see below:

```
markerOptions = {};
marker = new google.maps.Marker(new google.maps.LatLng(28.00000000, -81.0000099), markerOptions);
mmap_ad3019fbb049ec3ccc00ba3574b1af5de3587c47.addOverlay(marker);
google.maps.Event.addListener(marker, 'click', function () {
    marker.openInfoWindowHtml("Message 1");
});
markerOptions = {};
marker = new google.maps.Marker(new google.maps.LatLng(28.00000000, -81.0000095), markerOptions);
mmap_ad3019fbb049ec3ccc00ba3574b1af5de3587c47.addOverlay(marker);
google.maps.Event.addListener(marker, 'click', function () {
    marker.openInfoWindowHtml("Message 2");
});
```

Now all of the info bubbles would open at the second marker. After a little experimenting, I found that I can simply append iteration number of the foreach loop after "marker" in certain spots. For my application, this solved the problem. The new code would look like this:

```
markerOptions = {};
marker1 = new google.maps.Marker(new google.maps.LatLng(28.00000000, -81.0000099), markerOptions);
mmap_a350322d49e5b50d825513186c91ddcc93e7f871.addOverlay(marker1);
google.maps.Event.addListener(marker1, 'click', function () {
    marker1.openInfoWindowHtml("Message 1");
});
markerOptions = {};
marker2 = new google.maps.Marker(new google.maps.LatLng(28.00000000, -81.0000095), markerOptions);
mmap_a350322d49e5b50d825513186c91ddcc93e7f871.addOverlay(marker2);
google.maps.Event.addListener(marker2, 'click', function () {
    marker2.openInfoWindowHtml("Message 2");
});
```

I make no guarantees that it does or does not fix any issues that may arise with custom marker images. Whatever the case may be, this fixed my issue and I hope that it can fix others' :)
