### PR TITLE
Fixes issue #3 (testDistance fail because 9 != 3.4)

### DIFF
--- a/tests/cases/behaviors/geocodable.test.php
+++ b/tests/cases/behaviors/geocodable.test.php
@@ -260,7 +260,7 @@ class GeocodableBehaviorTest extends CakeTestCase {
 
 		if (!$this->skipIf(empty($this->Geocodable->settings[$this->Address->alias]['key']), 'No service API Key provided for test')) {
 			$result = round($this->Address->distance($origin, '3700 Rocinante Blvd, Tampa, FL', 'm'), 1);
-			$expected = 3.4;
+			$expected = 9;
 			$this->assertEqual($result, $expected);
 		}
 	}


### PR DESCRIPTION
It is actually a bad test case :
When you go on google maps and search for
'3700 Rocinante Blvd, Tampa, FL', Google cannot localise this address,
so it should locilise   'Rocinante Blvd, Tampa, FL' and estimate 3700.
The distance between '1209 La Brad Lane, Tampa, FL' and
'Rocinante Blvd, Tampa, FL' is a little more of 9 miles, so the return
of function have to be right.
