### PR TITLE
Refactored the "near" method in a custom find

### DIFF
--- a/models/geo_address.php
+++ b/models/geo_address.php
@@ -6,36 +6,5 @@ class GeoAddress extends AppModel {
 	 * @var array
 	 */
 	public $actsAs = array('Geocode.Geocodable');
-
-	/**
-	 * Overriden to implement 'near' find type, and support for 'count' with 'near'
-	 *
-	 * @param array $conditions SQL conditions array, or type of find operation (all / first / count / neighbors / list / threaded)
-	 * @param mixed $fields Either a single string of a field name, or an array of field names, or options for matching
-	 * @param string $order SQL ORDER BY conditions (e.g. "price DESC" or "name ASC")
-	 * @param integer $recursive The number of levels deep to fetch associated records
-	 * @return array Array of records
-	 */
-	public function find($conditions = null, $fields = array(), $order = null, $recursive = null) {
-		$findMethods = array_merge($this->_findMethods, array('near'=>true));
-		$findType = (is_string($conditions) && $conditions != 'count' && array_key_exists($conditions, $findMethods) ? $conditions : null);
-		if (empty($findType) && is_string($conditions) && $conditions == 'count' && !empty($fields['type']) && array_key_exists($fields['type'], $findMethods)) {
-			$findType = $fields['type'];
-			unset($fields['type']);
-		}
-
-		if ($findType == 'near' && $this->Behaviors->enabled('Geocodable')) {
-			$type = ($conditions == 'near' ? 'all' : $conditions);
-			$query = $fields;
-			if (!empty($query['address'])) {
-				foreach(array('address', 'unit', 'distance') as $field) {
-					$$field = isset($query[$field]) ? $query[$field] : null;
-					unset($query[$field]);
-				}
-				return $this->near($type, $address, $distance, $unit, $query);
-			}
-		}
-		return parent::find($conditions, $fields, $order, $recursive);
-	}
 }
 ?>

--- a/tests/cases/behaviors/geocodable.test.php
+++ b/tests/cases/behaviors/geocodable.test.php
@@ -141,7 +141,11 @@ class GeocodableBehaviorTest extends CakeTestCase {
 			'state' => 'FL'
 		));
 		$expected = array(28.0792, -82.4735);
-		$this->assertEqual($result, $expected);
+		$this->assertEqual(count($result), count($expected));
+		foreach ($expected as $key => $value) {
+			$this->assertTrue(isset($result[$key]));
+			$this->assertWithinMargin($result[$key], $value, 0.001);
+		}
 
 		$this->expectError();
 		$result = $this->Address->geocode(array(
@@ -284,11 +288,16 @@ class GeocodableBehaviorTest extends CakeTestCase {
 				$result[$key] = round($distance, 3);
 			}
 			$expected = array(
-				'14348 N Rome Ave, Tampa, 33613 FL' => 0.257,
-				'1180 Magdalene Hill, Florida, US' => 0.499,
-				'9106 El Portal Dr, Tampa, FL' => 5.331
+				'14348 N Rome Ave, Tampa, 33613 FL' => 0.25,
+				'1180 Magdalene Hill, Florida, US' => 0.50,
+				'13216 Forest Hills Dr, Tampa, FL' => 1.23,
+				'9106 El Portal Dr, Tampa, FL' => 5.33
 			);
-			$this->assertEqual($result, $expected);
+			$this->assertEqual(count($result), count($expected));
+			foreach ($expected as $key => $value) {
+				$this->assertTrue(isset($result[$key]));
+				$this->assertWithinMargin($result[$key], $value, 0.01);
+			}
 		}
 
 		$result = $this->Address->near('all', '1209 La Brad Lane, Tampa, FL', 1);
@@ -299,10 +308,14 @@ class GeocodableBehaviorTest extends CakeTestCase {
 				$result[$key] = round($distance, 3);
 			}
 			$expected = array(
-				'14348 N Rome Ave, Tampa, 33613 FL' => 0.257,
-				'1180 Magdalene Hill, Florida, US' => 0.499
+				'14348 N Rome Ave, Tampa, 33613 FL' => 0.25,
+				'1180 Magdalene Hill, Florida, US' => 0.50
 			);
-			$this->assertEqual($result, $expected);
+			$this->assertEqual(count($result), count($expected));
+			foreach ($expected as $key => $value) {
+				$this->assertTrue(isset($result[$key]));
+				$this->assertWithinMargin($result[$key], $value, 0.01);
+			}
 		}
 
 		$result = $this->Address->near('count', '1209 La Brad Lane, Tampa, FL', 1);
@@ -316,10 +329,14 @@ class GeocodableBehaviorTest extends CakeTestCase {
 				$result[$key] = round($distance, 3);
 			}
 			$expected = array(
-				'14348 N Rome Ave, Tampa, 33613 FL' => 0.160,
-				'1180 Magdalene Hill, Florida, US' => 0.310
+				'14348 N Rome Ave, Tampa, 33613 FL' => 0.16,
+				'1180 Magdalene Hill, Florida, US' => 0.31
 			);
-			$this->assertEqual($result, $expected);
+			$this->assertEqual(count($result), count($expected));
+			foreach ($expected as $key => $value) {
+				$this->assertTrue(isset($result[$key]));
+				$this->assertWithinMargin($result[$key], $value, 0.01);
+			}
 		}
 	}
 
@@ -428,59 +445,6 @@ class GeocodableBehaviorTest extends CakeTestCase {
 		}
 	}
 
-	public function testFind() {
-		$result = $this->Address->find('near', array('address'=>array(25.7953, -80.2789)));
-		$expected = 331;
-		$this->assertTrue(!empty($result[0]));
-		$this->assertEqual(ceil($result[0][$this->Address->alias]['distance']), $expected);
-
-		$result = $this->Address->find('near', array('address'=>'1209 La Brad Lane, Tampa, FL'));
-		$this->assertTrue(!empty($result));
-		if (!empty($result)) {
-			$result = Set::combine($result, '/' . $this->Address->alias . '/address', '/' . $this->Address->alias . '/distance');
-			foreach($result as $key => $distance) {
-				$result[$key] = round($distance, 3);
-			}
-			$expected = array(
-				'14348 N Rome Ave, Tampa, 33613 FL' => 0.257,
-				'1180 Magdalene Hill, Florida, US' => 0.499,
-				'9106 El Portal Dr, Tampa, FL' => 5.331
-			);
-			$this->assertEqual($result, $expected);
-		}
-
-		$result = $this->Address->find('near', array('address'=>'1209 La Brad Lane, Tampa, FL', 'distance'=>1));
-		$this->assertTrue(!empty($result));
-		if (!empty($result)) {
-			$result = Set::combine($result, '/' . $this->Address->alias . '/address', '/' . $this->Address->alias . '/distance');
-			foreach($result as $key => $distance) {
-				$result[$key] = round($distance, 3);
-			}
-			$expected = array(
-				'14348 N Rome Ave, Tampa, 33613 FL' => 0.257,
-				'1180 Magdalene Hill, Florida, US' => 0.499
-			);
-			$this->assertEqual($result, $expected);
-		}
-
-		$result = $this->Address->find('count', array('type'=>'near', 'address'=>'1209 La Brad Lane, Tampa, FL', 'distance'=>1));
-		$this->assertEqual($result, 2);
-
-		$result = $this->Address->find('near', array('address'=>'1209 La Brad Lane, Tampa, FL', 'distance'=>0.5, 'unit'=>'m'));
-		$this->assertTrue(!empty($result));
-		if (!empty($result)) {
-			$result = Set::combine($result, '/' . $this->Address->alias . '/address', '/' . $this->Address->alias . '/distance');
-			foreach($result as $key => $distance) {
-				$result[$key] = round($distance, 3);
-			}
-			$expected = array(
-				'14348 N Rome Ave, Tampa, 33613 FL' => 0.160,
-				'1180 Magdalene Hill, Florida, US' => 0.310
-			);
-			$this->assertEqual($result, $expected);
-		}
-	}
-
 	public function testPaginate() {
 		$Controller = new Controller();
 		$Controller->uses = array('TestAddress');
@@ -502,7 +466,11 @@ class GeocodableBehaviorTest extends CakeTestCase {
 				'14348 N Rome Ave, Tampa, 33613 FL' => 0.257,
 				'1180 Magdalene Hill, Florida, US' => 0.499
 			);
-			$this->assertEqual($result, $expected);
+			$this->assertEqual(count($result), count($expected));
+			foreach ($expected as $key => $value) {
+				$this->assertTrue(isset($result[$key]));
+				$this->assertWithinMargin($result[$key], $value, 0.01);
+			}
 		}
 
 		$Controller->paginate = array('TestAddress' => array(
@@ -518,9 +486,14 @@ class GeocodableBehaviorTest extends CakeTestCase {
 				$result[$key] = round($distance, 3);
 			}
 			$expected = array(
+				'13216 Forest Hills Dr, Tampa, FL' => 1.23,
 				'9106 El Portal Dr, Tampa, FL' => 5.331
 			);
-			$this->assertEqual($result, $expected);
+			$this->assertEqual(count($result), count($expected));
+			foreach ($expected as $key => $value) {
+				$this->assertTrue(isset($result[$key]));
+				$this->assertWithinMargin($result[$key], $value, 0.01);
+			}
 		}
 
 		$Controller->paginate = array('TestAddress' => array(
@@ -538,7 +511,11 @@ class GeocodableBehaviorTest extends CakeTestCase {
 				'14348 N Rome Ave, Tampa, 33613 FL' => 0.160,
 				'1180 Magdalene Hill, Florida, US' => 0.310
 			);
-			$this->assertEqual($result, $expected);
+			$this->assertEqual(count($result), count($expected));
+			foreach ($expected as $key => $value) {
+				$this->assertTrue(isset($result[$key]));
+				$this->assertWithinMargin($result[$key], $value, 0.01);
+			}
 		}
 
 		$Controller->paginate = array('TestAddress' => array(
@@ -555,7 +532,11 @@ class GeocodableBehaviorTest extends CakeTestCase {
 			$expected = array(
 				'14348 N Rome Ave, Tampa, 33613 FL' => 0.160
 			);
-			$this->assertEqual($result, $expected);
+			$this->assertEqual(count($result), count($expected));
+			foreach ($expected as $key => $value) {
+				$this->assertTrue(isset($result[$key]));
+				$this->assertWithinMargin($result[$key], $value, 0.01);
+			}
 		}
 	}
 }


### PR DESCRIPTION
For retrocompatibility, the near() method now uses the custom find.
The function find in GeoAddress has no sense anymore and has been removed.
